### PR TITLE
Add support for the standard Web Push protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "dependencies": {
     "body-parser": "^1.14.2",
     "express": "^4.13.4",
-    "sw-toolbox": "^3.1.1"
+    "sw-toolbox": "^3.1.1",
+    "web-push": "^1.0.2"
   },
   "devDependencies": {
-    "node-gcm": "^0.14.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -3,9 +3,10 @@ var app = express();
 var bodyParser = require('body-parser');
 var jsonParser = bodyParser.json();
 var PORT = process.env.PORT || 8000;
-var gcm = require('node-gcm');
+var webPush = require('web-push');
 
 // The GCM API key is AIzaSyDNlm9R_w_0FDGjSM1fzyx5I5JnJBXACqU
+webPush.setGCMAPIKey('AIzaSyDNlm9R_w_0FDGjSM1fzyx5I5JnJBXACqU');
 
 app.use(express.static(__dirname));
 
@@ -13,26 +14,21 @@ app.use(bodyParser.json());
 
 app.use("/push", function(req, res, next) {
   if (req.body.action === 'subscribe') {
-    var subEndpoint = req.body.subscription.endpoint;
-    var senderToken = subEndpoint.slice(40, subEndpoint.length);
-    if(!senderToken){
-      res.status(500)
-         .send({text:"No sender token found!!!",status:"500"});
-    }
+    var endpoint = req.body.subscription.endpoint;
 
-    var message = new gcm.Message({});
-    var sender = new gcm.Sender('AIzaSyDNlm9R_w_0FDGjSM1fzyx5I5JnJBXACqU');
-    var registrationTokens = [];
-    registrationTokens.push(senderToken);
     setTimeout(function() {
-      console.log("[[SENDING PUSH NOW: "+registrationTokens+"]]");
-      sender.send(message, {
-        registrationTokens: registrationTokens
-      }, function(err, response) {
-        if (err)
-          console.error("PUSH ERR: " + err);
-        else
+      console.log("[[SENDING PUSH NOW: " + endpoint + "]]");
+
+      webPush.sendNotification(endpoint)
+      .then(function(response) {
+        if (response) {
           console.log("PUSH RESPONSE: ", response);
+        } else {
+          console.log("PUSH SENT");
+        }
+      })
+      .catch(function(err) {
+        console.error("PUSH ERR: " + err);
       });
     }, 5000);
     res.send({text:'Sending push in 5',status:"200"});


### PR DESCRIPTION
Fixes #1.

The `web-push` library automatically uses the standard Web Push protocol for Web Push endpoints (Firefox) and the GCM protocol for GCM endpoints (Chrome currently, but it will soon switch to the standard protocol).
